### PR TITLE
fix: move pngjs and pixelmatch to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "diff": "^8.0.3",
     "esbuild": "^0.25.4",
     "fontoxpath": "^3.34.0",
+    "pixelmatch": "^7.1.0",
+    "pngjs": "^7.0.0",
     "postcss": "^8.5.6",
     "svgpath": "^2.6.0",
     "typescript": "^5.8.3",
@@ -77,8 +79,6 @@
     "ajv-formats": "^3.0.1",
     "oxfmt": "^0.26.0",
     "oxlint": "^1.39.0",
-    "pixelmatch": "^7.1.0",
-    "pngjs": "^7.0.0",
     "react": "19"
   }
 }


### PR DESCRIPTION
## Summary

- Moves `pngjs` and `pixelmatch` from `devDependencies` to `dependencies`

## Problem

When installing `figma-use` globally with `npm install -g figma-use`, users get an error:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'pngjs' imported from
.../node_modules/figma-use/dist/cli/index.js
```

## Root Cause

These packages are marked as `--external` in the build script (line 47 of package.json):

```bash
--external pngjs --external pixelmatch
```

This means they're not bundled into `dist/cli/index.js` and must be available at runtime. However, they were listed in `devDependencies`, which npm doesn't install for end users.

## Solution

Move both packages to `dependencies` so they're installed when users install the package.

## Testing

Verified that `npm install --omit=dev` now correctly installs both `pngjs` and `pixelmatch`.