### PR TITLE
fix: bootstrap figma plugin API via webpack internals on Figma 126+

### DIFF
--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -12,6 +12,7 @@ let rpcInjected = false
 let currentRpcHash: string | null = null
 let useDaemon: boolean | null = null
 let esbuildModule: typeof import('esbuild') | null = null
+let figmaApiBootstrapped = false
 
 function getPluginDir(): string {
   // Works both in dev (src/) and bundled (dist/)
@@ -81,7 +82,61 @@ async function buildRpcBundle(): Promise<{ code: string; hash: string }> {
   return { code, hash }
 }
 
+const FIGMA_API_BOOTSTRAP = `
+(function() {
+  if (typeof figma !== 'undefined' && typeof figma.createFrame === 'function') return 'already available';
+
+  if (!window.__webpackRequire__) {
+    window.webpackChunk_figma_web_bundler.push([
+      ['__figma_use_' + Date.now()], {},
+      r => window.__webpackRequire__ = r
+    ]);
+  }
+
+  const r = window.__webpackRequire__;
+  let defineVm;
+  for (const id in r.m) {
+    if (r.m[id].toString().includes('apiMode:e,pluginID')) {
+      const hit = Object.values(r(id)).find(
+        v => typeof v === 'function' && v.toString().includes('apiMode')
+      );
+      if (hit) { defineVm = hit; break; }
+    }
+  }
+
+  if (!defineVm) throw new Error('Could not find defineVmFunction in Figma internals');
+
+  const {vm} = defineVm({
+    apiMode: 'PLUGIN',
+    pluginID: 'figma-use-bridge',
+    enableNativeJsx: false,
+    disableWebpageSync: false,
+    sceneGraph: null
+  });
+
+  window.figma = vm.scope.figma;
+  return 'bootstrapped';
+})()
+`
+
+async function ensureFigmaApi(): Promise<void> {
+  if (figmaApiBootstrapped) {
+    // Verify it's still there (page may have reloaded)
+    const check = await cdpEval<boolean>('typeof figma !== "undefined" && typeof figma.createFrame === "function"')
+    if (check) return
+  }
+
+  const result = await cdpEval<string>(FIGMA_API_BOOTSTRAP)
+  if (result !== 'bootstrapped' && result !== 'already available') {
+    throw new Error('Failed to bootstrap Figma plugin API: ' + result)
+  }
+  figmaApiBootstrapped = true
+}
+
 async function ensureRpcInjected(): Promise<void> {
+  // Bootstrap the figma plugin API in the page context first
+  await ensureFigmaApi()
+
   const { code, hash } = await buildRpcBundle()
 
   // Check if RPC is already injected with same version


### PR DESCRIPTION
> [!NOTE]
> This PR was created by an LLM (Claude). The result has been verified by me. Before this PR I was unable to use figma-use at all — every command crashed with `loadFontAsync` errors. After this fix, it connects and works correctly.

## Demo


https://github.com/user-attachments/assets/70e1eeb3-0b93-491f-a892-4f172d37ae9f



## Summary

- Fixes the `TypeError: Cannot read properties of undefined (reading 'loadFontAsync')` error on Figma 126+ when using both port-based (`--remote-debugging-port=9222`) and pipe-based (`--remote-debugging-pipe`) transports
- Bootstraps the `figma` plugin API in the page context before injecting the RPC bundle by using Figma's internal `defineVmFunction` via webpack modules
- No changes needed to the plugin code (`packages/plugin/`) — the existing RPC code works as-is once `window.figma` is available

## Problem

On Figma 126+, the `figma` plugin API global is not available in the page's JavaScript context. When figma-use injects the RPC plugin bundle via CDP `Runtime.evaluate`, the code crashes immediately at module load time because `shared.ts` eagerly calls `figma.loadFontAsync({ family: 'Inter', style: 'Regular' })`.

The `figma` global only exists inside Figma's plugin sandbox (created by an internal `defineVmFunction`), not in the page context where `Runtime.evaluate` runs.

## Solution

Added a bootstrap step in `ensureRpcInjected()` that runs before the RPC bundle injection:

1. Hooks into Figma's webpack internals via `webpackChunk_figma_web_bundler`
2. Finds `defineVmFunction` — the internal function that creates plugin sandboxes
3. Creates a VM sandbox with `apiMode: 'PLUGIN'`
4. Extracts `vm.scope.figma` (the real plugin API with `createFrame`, `currentPage`, `loadFontAsync`, etc.)
5. Exposes it as `window.figma` in the page context

The bootstrap is idempotent — it checks if `figma` is already available before creating a new sandbox, and re-bootstraps if the page reloads.

## Test plan

- [x] `figma-use status` — reports connected with file name
- [x] `figma-use create rect` — creates rectangles in the design
- [x] `figma-use create text` — creates text nodes
- [x] `figma-use render --stdin` — renders JSX to Figma
- [x] `figma-use eval "figma.currentPage.name"` — returns page name
- [x] Tested on Figma 126.1.4 (macOS) with `--remote-debugging-port=9222`

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)