### PR TITLE
fix: bootstrap Figma plugin API on Figma 126+ (remote debugging)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Safer Figma 126+ bootstrap fallback** — isolate the webpack-internal plugin API bootstrap behind a compatibility fallback. RPC injection now probes the legacy path first, falls back to the Figma 126+ bootstrap only when needed, and remembers the last working strategy for subsequent injections.
+
 ## [0.13.1] - 2026-02-22
 
 ### Fixed

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'url'
 
 import { cdpEval } from './cdp.ts'
 import { isDaemonAvailable, callDaemon } from './daemon/index.ts'
+import { injectRpcBundleWithFallback, type RpcInjectionStrategy } from './rpc-bootstrap.ts'
 
 export { printResult, printError, formatResult } from './output.ts'
 export { getFileKey } from './cdp.ts'
@@ -13,6 +14,7 @@ let currentRpcHash: string | null = null
 let useDaemon: boolean | null = null
 let esbuildModule: typeof import('esbuild') | null = null
 let figmaApiBootstrapped = false
+let rpcInjectionStrategy: RpcInjectionStrategy | null = null
 
 function getPluginDir(): string {
   // Works both in dev (src/) and bundled (dist/)
@@ -35,6 +37,8 @@ import { existsSync, readFileSync, writeFileSync, statSync } from 'fs'
 import { tmpdir } from 'os'
 
 const RPC_CACHE_PATH = join(tmpdir(), 'figma-use-rpc-cache.json')
+const FIGMA_API_READY_CHECK =
+  '(() => { const api = window.__figmaPluginApi; return !!api && typeof api.getNodeByIdAsync === "function" && typeof api.loadFontAsync === "function"; })()'
 
 async function buildRpcBundle(): Promise<{ code: string; hash: string }> {
   const pluginDir = getPluginDir()
@@ -85,7 +89,7 @@ async function buildRpcBundle(): Promise<{ code: string; hash: string }> {
 
 const FIGMA_API_BOOTSTRAP = `
 (function() {
-  if (window.__figmaPluginApi && typeof window.__figmaPluginApi.createFrame === 'function') return 'already available';
+  if (window.__figmaPluginApi && typeof window.__figmaPluginApi.getNodeByIdAsync === 'function' && typeof window.__figmaPluginApi.loadFontAsync === 'function') return 'already available';
 
   if (!window.__webpackRequire__) {
     window.webpackChunk_figma_web_bundler.push([
@@ -125,7 +129,7 @@ const FIGMA_API_BOOTSTRAP = `
 async function ensureFigmaApi(): Promise<void> {
   if (figmaApiBootstrapped) {
     // Verify it's still there (page may have reloaded)
-    const check = await cdpEval<boolean>('window.__figmaPluginApi && typeof window.__figmaPluginApi.createFrame === "function"')
+    const check = await cdpEval<boolean>(FIGMA_API_READY_CHECK)
     if (check) return
   }
 
@@ -137,9 +141,6 @@ async function ensureFigmaApi(): Promise<void> {
 }
 
 async function ensureRpcInjected(): Promise<void> {
-  // Bootstrap the figma plugin API in the page context first
-  await ensureFigmaApi()
-
   const { code, hash } = await buildRpcBundle()
 
   // Check if RPC is already injected with same version
@@ -148,16 +149,13 @@ async function ensureRpcInjected(): Promise<void> {
     if (remoteHash === hash) return
   }
 
-  // Wrap RPC bundle so local `figma` parameter shadows the broken window.figma getter
-  const wrappedCode = `;(function(figma) {\n${code}\n})(window.__figmaPluginApi);`
-  await cdpEval(wrappedCode)
-  await cdpEval(`window.__figmaRpcHash = ${JSON.stringify(hash)}`)
-
-  const ready = await cdpEval<boolean>('typeof window.__figmaRpc === "function"')
-  if (!ready) {
-    throw new Error('Failed to inject RPC into Figma')
-  }
-
+  rpcInjectionStrategy = await injectRpcBundleWithFallback({
+    code,
+    hash,
+    preferredStrategy: rpcInjectionStrategy,
+    evaluate: cdpEval,
+    ensureFigmaApi
+  })
   rpcInjected = true
   currentRpcHash = hash
 }

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -12,6 +12,7 @@ let rpcInjected = false
 let currentRpcHash: string | null = null
 let useDaemon: boolean | null = null
 let esbuildModule: typeof import('esbuild') | null = null
+let figmaApiBootstrapped = false
 
 function getPluginDir(): string {
   // Works both in dev (src/) and bundled (dist/)
@@ -65,7 +66,8 @@ async function buildRpcBundle(): Promise<{ code: string; hash: string }> {
     write: false,
     format: 'iife',
     target: 'es2020',
-    minify: true
+    minifySyntax: true,
+    minifyWhitespace: true
   })
 
   const code = result.outputFiles![0]!.text
@@ -81,7 +83,63 @@ async function buildRpcBundle(): Promise<{ code: string; hash: string }> {
   return { code, hash }
 }
 
+const FIGMA_API_BOOTSTRAP = `
+(function() {
+  if (window.__figmaPluginApi && typeof window.__figmaPluginApi.createFrame === 'function') return 'already available';
+
+  if (!window.__webpackRequire__) {
+    window.webpackChunk_figma_web_bundler.push([
+      ['__figma_use_' + Date.now()], {},
+      r => window.__webpackRequire__ = r
+    ]);
+  }
+
+  const r = window.__webpackRequire__;
+  let defineVm;
+  for (const id in r.m) {
+    if (r.m[id].toString().includes('apiMode:e,pluginID')) {
+      const hit = Object.values(r(id)).find(
+        v => typeof v === 'function' && v.toString().includes('apiMode')
+      );
+      if (hit) { defineVm = hit; break; }
+    }
+  }
+
+  if (!defineVm) throw new Error('Could not find defineVmFunction in Figma internals');
+
+  // The wrapper may return figma directly or {vm: {scope: {figma}}}
+  const result = defineVm({
+    enableNativeJsx: false,
+    sceneGraph: null
+  });
+
+  // Store on a custom property - window.figma is a non-configurable
+  // getter/setter controlled by Figma that discards assignments
+  window.__figmaPluginApi = (result && result.vm && result.vm.scope)
+    ? result.vm.scope.figma
+    : result;
+  return 'bootstrapped';
+})()
+`
+
+async function ensureFigmaApi(): Promise<void> {
+  if (figmaApiBootstrapped) {
+    // Verify it's still there (page may have reloaded)
+    const check = await cdpEval<boolean>('window.__figmaPluginApi && typeof window.__figmaPluginApi.createFrame === "function"')
+    if (check) return
+  }
+
+  const result = await cdpEval<string>(FIGMA_API_BOOTSTRAP)
+  if (result !== 'bootstrapped' && result !== 'already available') {
+    throw new Error('Failed to bootstrap Figma plugin API: ' + result)
+  }
+  figmaApiBootstrapped = true
+}
+
 async function ensureRpcInjected(): Promise<void> {
+  // Bootstrap the figma plugin API in the page context first
+  await ensureFigmaApi()
+
   const { code, hash } = await buildRpcBundle()
 
   // Check if RPC is already injected with same version
@@ -90,8 +148,9 @@ async function ensureRpcInjected(): Promise<void> {
     if (remoteHash === hash) return
   }
 
-  // Inject fresh RPC
-  await cdpEval(code)
+  // Wrap RPC bundle so local `figma` parameter shadows the broken window.figma getter
+  const wrappedCode = `;(function(figma) {\n${code}\n})(window.__figmaPluginApi);`
+  await cdpEval(wrappedCode)
   await cdpEval(`window.__figmaRpcHash = ${JSON.stringify(hash)}`)
 
   const ready = await cdpEval<boolean>('typeof window.__figmaRpc === "function"')

--- a/packages/cli/src/rpc-bootstrap.ts
+++ b/packages/cli/src/rpc-bootstrap.ts
@@ -1,0 +1,71 @@
+export type RpcInjectionStrategy = 'legacy' | 'bootstrapped'
+
+export interface InjectRpcBundleOptions {
+  code: string
+  hash: string
+  preferredStrategy?: RpcInjectionStrategy | null
+  evaluate: <T = unknown>(code: string, timeout?: number) => Promise<T>
+  ensureFigmaApi: () => Promise<void>
+}
+
+const RPC_READY_CHECK = 'typeof window.__figmaRpc === "function"'
+const RPC_HEALTH_CHECK = 'window.__figmaRpc("get-current-page", undefined)'
+const RPC_RESET = 'delete window.__figmaRpc; delete window.__figmaRpcHash'
+
+export function getRpcInjectionStrategyOrder(
+  preferredStrategy?: RpcInjectionStrategy | null
+): RpcInjectionStrategy[] {
+  return preferredStrategy === 'bootstrapped'
+    ? ['bootstrapped', 'legacy']
+    : ['legacy', 'bootstrapped']
+}
+
+export function wrapRpcBundle(code: string): string {
+  return `;(function(figma) {\n${code}\n})(window.__figmaPluginApi);`
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export async function injectRpcBundleWithFallback({
+  code,
+  hash,
+  preferredStrategy,
+  evaluate,
+  ensureFigmaApi
+}: InjectRpcBundleOptions): Promise<RpcInjectionStrategy> {
+  const attempts = getRpcInjectionStrategyOrder(preferredStrategy)
+  const failures: string[] = []
+
+  for (const strategy of attempts) {
+    try {
+      try {
+        await evaluate(RPC_RESET)
+      } catch {
+        // Best-effort cleanup between attempts
+      }
+
+      if (strategy === 'bootstrapped') {
+        await ensureFigmaApi()
+        await evaluate(wrapRpcBundle(code))
+      } else {
+        await evaluate(code)
+      }
+
+      await evaluate(`window.__figmaRpcHash = ${JSON.stringify(hash)}`)
+
+      const ready = await evaluate<boolean>(RPC_READY_CHECK)
+      if (!ready) {
+        throw new Error('window.__figmaRpc was not defined')
+      }
+
+      await evaluate(RPC_HEALTH_CHECK)
+      return strategy
+    } catch (error) {
+      failures.push(`${strategy}: ${formatError(error)}`)
+    }
+  }
+
+  throw new Error(`Failed to inject RPC into Figma (${failures.join(' | ')})`)
+}

--- a/packages/cli/tests/rpc-bootstrap.test.ts
+++ b/packages/cli/tests/rpc-bootstrap.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  getRpcInjectionStrategyOrder,
+  injectRpcBundleWithFallback,
+  wrapRpcBundle
+} from '../src/rpc-bootstrap.ts'
+
+describe('rpc bootstrap', () => {
+  test('prefers legacy strategy by default', () => {
+    expect(getRpcInjectionStrategyOrder()).toEqual(['legacy', 'bootstrapped'])
+  })
+
+  test('prefers last known bootstrapped strategy when requested', () => {
+    expect(getRpcInjectionStrategyOrder('bootstrapped')).toEqual(['bootstrapped', 'legacy'])
+  })
+
+  test('uses legacy injection when health check passes', async () => {
+    const calls: string[] = []
+    let bootstrapped = false
+
+    const strategy = await injectRpcBundleWithFallback({
+      code: 'legacy bundle',
+      hash: 'abc123',
+      evaluate: async <T>(code: string) => {
+        calls.push(code)
+        if (code === 'typeof window.__figmaRpc === "function"') return true as T
+        if (code === 'window.__figmaRpc("get-current-page", undefined)') {
+          return { id: '1:1', name: 'Page 1' } as T
+        }
+        return undefined as T
+      },
+      ensureFigmaApi: async () => {
+        bootstrapped = true
+      }
+    })
+
+    expect(strategy).toBe('legacy')
+    expect(bootstrapped).toBe(false)
+    expect(calls).toContain('legacy bundle')
+    expect(calls).not.toContain(wrapRpcBundle('legacy bundle'))
+  })
+
+  test('falls back to bootstrapped injection when legacy probe fails', async () => {
+    const calls: string[] = []
+    let legacyInjected = false
+    let bootstrapped = 0
+
+    const strategy = await injectRpcBundleWithFallback({
+      code: 'legacy bundle',
+      hash: 'def456',
+      evaluate: async <T>(code: string) => {
+        calls.push(code)
+
+        if (code === 'legacy bundle') {
+          legacyInjected = true
+          return undefined as T
+        }
+
+        if (code === 'typeof window.__figmaRpc === "function"') return true as T
+
+        if (code === 'window.__figmaRpc("get-current-page", undefined)') {
+          if (legacyInjected && bootstrapped === 0) {
+            throw new Error("Cannot read properties of undefined (reading 'currentPage')")
+          }
+          return { id: '1:2', name: 'Fallback Page' } as T
+        }
+
+        return undefined as T
+      },
+      ensureFigmaApi: async () => {
+        bootstrapped++
+      }
+    })
+
+    expect(strategy).toBe('bootstrapped')
+    expect(bootstrapped).toBe(1)
+    expect(calls).toContain('legacy bundle')
+    expect(calls).toContain(wrapRpcBundle('legacy bundle'))
+  })
+
+  test('includes both strategy failures in the error', async () => {
+    await expect(
+      injectRpcBundleWithFallback({
+        code: 'legacy bundle',
+        hash: 'ghi789',
+        evaluate: async () => {
+          throw new Error('boom')
+        },
+        ensureFigmaApi: async () => {}
+      })
+    ).rejects.toThrow('legacy: boom')
+
+    await expect(
+      injectRpcBundleWithFallback({
+        code: 'legacy bundle',
+        hash: 'ghi789',
+        evaluate: async () => {
+          throw new Error('boom')
+        },
+        ensureFigmaApi: async () => {}
+      })
+    ).rejects.toThrow('bootstrapped: boom')
+  })
+})


### PR DESCRIPTION
## Problem

On Figma 126.2.5, `figma-use eval` and all CLI commands fail with `TypeError: Cannot read properties of undefined (reading 'loadFontAsync')` when using the `--remote-debugging-port` approach. Related to #11, builds on the approach from #12.

## Root Causes & Fixes

Four issues discovered through debugging:

### 1. `defineVm` return shape changed
The internal wrapper already extracts `.vm.scope.figma` and returns it directly on 126.2.5.

**Fix:** Handle both return shapes.

### 2. `window.figma` is a non-configurable no-op setter
Figma defines `window.figma` as a getter/setter where the setter silently discards any value.

```js
Object.getOwnPropertyDescriptor(window, 'figma')
// { enumerable: false, configurable: false, get: fn, set: fn }
// setter is a no-op, getter returns undefined when no plugin active
```

**Fix:** Store the bootstrapped API on `window.__figmaPluginApi`.

### 3. RPC bundle references `figma` as an undefined global
**Fix:** Wrap the injected bundle: `(function(figma) { ...bundle... })(window.__figmaPluginApi)`

### 4. `minifyIdentifiers` breaks the IIFE wrapper
esbuild renames the `figma` parameter, breaking the shadow.

**Fix:** Use `minifySyntax` + `minifyWhitespace` only.

## Backwards-compatible fallback

The webpack bootstrap is only needed on Figma 126+. To avoid breaking older versions where `window.figma` works natively, RPC injection uses a two-strategy fallback (extracted into `rpc-bootstrap.ts`):

1. **Legacy** (tried first) — inject the RPC bundle via plain `eval`, no webpack hooks. Works on pre-126 Figma where the `figma` global is available.
2. **Bootstrapped** (fallback) — run the webpack bootstrap to create `window.__figmaPluginApi`, then inject the bundle wrapped in an IIFE that shadows `figma`.

Each strategy is validated with a health check (`get-current-page` RPC call). If legacy passes, the bootstrap is never attempted. The winning strategy is remembered for subsequent injections in the same session.

5 unit tests cover strategy ordering, legacy success path, fallback to bootstrapped, and error aggregation.

## Testing

Verified on Figma 126.2.5 (desktop, macOS):

```
$ figma-use eval 'return figma.fileKey'
b4u3xfBVIFRIAclYsPnlYu

$ figma-use eval 'return figma.currentPage.name'
My Orders

$ figma-use eval 'const node = await figma.getNodeByIdAsync("6:1768"); return node.name'
Card Order

$ figma-use eval '
  const node = await figma.getNodeByIdAsync("6:1768");
  const bv = node.boundVariables;
  const varIds = [];
  for (const key in bv) {
    const val = bv[key];
    if (Array.isArray(val)) val.forEach(v => varIds.push(v.id));
    else if (val?.id) varIds.push(val.id);
  }
  const resolved = {};
  for (const id of varIds) {
    const v = await figma.variables.getVariableByIdAsync(id);
    if (v) resolved[v.name] = v.resolvedType;
  }
  return resolved;
'
{
  "size/spacer/medium": "FLOAT",
  "size/border-radius/card": "FLOAT",
  "size/border/small": "FLOAT",
  "color/background/card/default": "COLOR",
  "color/border/card/default": "COLOR"
}
```

## Changes

- `packages/cli/src/client.ts` — bootstrap logic + fallback wiring
- `packages/cli/src/rpc-bootstrap.ts` — new module with two-strategy injection and health check
- `packages/cli/tests/rpc-bootstrap.test.ts` — 5 unit tests
- `CHANGELOG.md` — unreleased entry