### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ figma-use status
 
 That's it. No plugins to install.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/dannote-figma-use).
+
 ## Two Modes
 
 Imperative — one command at a time:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/dannote-figma-use).