### PR TITLE
feat: custom CDP port via --port flag and FIGMA_PORT env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Custom CDP port via `--port` flag or `FIGMA_PORT` env** — connect to Figma running on any remote-debugging port, not just the default 9222. Works across all commands (`figma-use get components --port 9333`), the daemon (`figma-use daemon start --port 9333`), and error messages now show the correct port in the launch hint. The daemon detects and reports port mismatches with a restart hint.
+
 ## [0.13.3] - 2026-04-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -527,6 +527,14 @@ Includes [SKILL.md](./SKILL.md) — a reference for Claude Code, Cursor, and oth
 
 figma-use communicates directly with Figma via Chrome DevTools Protocol (CDP). Just start Figma with `--remote-debugging-port=9222` and you're ready.
 
+> **Non-default port?** Pass `--port <N>` to any command, or set the `FIGMA_PORT` env var:
+> ```bash
+> open -a Figma --args --remote-debugging-port=9333
+> figma-use get components --port 9333
+> # or
+> FIGMA_PORT=9333 figma-use get components
+> ```
+
 Commands are executed via `Runtime.evaluate` in Figma's JavaScript context, with full access to the Plugin API.
 
 ### Daemon

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -432,6 +432,7 @@ Keeps CDP connection warm for faster sequential commands (~25% speedup). Also re
 ```bash
 figma-use daemon start                     # Start daemon in background
 figma-use daemon start --pipe              # Launch Figma with debug pipe (no patching needed)
+figma-use daemon start --port 9333         # Daemon connects to a non-default CDP port
 figma-use daemon start -f                  # Run in foreground
 figma-use daemon stop                      # Stop daemon (kills Figma in pipe mode)
 figma-use daemon status                    # Check daemon status
@@ -440,6 +441,8 @@ figma-use daemon restart --pipe            # Restart with pipe transport
 ```
 
 When daemon is running, all commands automatically use it. Falls back to direct CDP if daemon is unavailable.
+
+If you started the daemon on a custom port, pass `--port <N>` to commands too (or set `FIGMA_PORT`). A mismatch is reported with a restart hint.
 
 ## System
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -44,6 +44,12 @@ figma --remote-debugging-port=9222
 
 Start Figma with `--remote-debugging-port=9222` and you're ready.
 
+> **Non-default port?** If Figma is on another port, pass `--port <N>` to any command (or set the `FIGMA_PORT` env var). Errors will show the correct port.
+> ```bash
+> open -a Figma --args --remote-debugging-port=9333
+> figma-use get components --port 9333
+> ```
+
 ## Two Modes
 
 **Imperative** — single operations:

--- a/packages/cli/src/cdp.ts
+++ b/packages/cli/src/cdp.ts
@@ -13,6 +13,53 @@ export function usePipeTransport(): void {
   pipeMode = true
 }
 
+export function isPipeTransport(): boolean {
+  return isPipeMode()
+}
+
+// CDP port resolution: --port flag (parsed from argv for any subcommand)
+// → FIGMA_PORT env → default 9222. Read once and cached.
+const DEFAULT_CDP_PORT = 9222
+let cachedCdpPort: number | null = null
+
+export function getCdpPort(): number {
+  if (cachedCdpPort !== null) return cachedCdpPort
+
+  let port = DEFAULT_CDP_PORT
+
+  // Prefer an explicit --port flag on the command line. Citty does not
+  // propagate root args into subcommands, so we parse argv directly — this
+  // works regardless of which subcommand is running.
+  const argv = process.argv
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!
+    if (a === '--port' && i + 1 < argv.length) {
+      port = Number(argv[++i])
+      break
+    }
+    const eq = '--port='
+    if (a.startsWith(eq)) {
+      port = Number(a.slice(eq.length))
+      break
+    }
+  }
+
+  // FIGMA_PORT env is the secondary fallback (matches FIGMA_PIPE/FIGMA_BIN).
+  if (!argv.includes('--port') && !argv.some((a) => a.startsWith('--port='))) {
+    const envPort = process.env.FIGMA_PORT
+    if (envPort) port = Number(envPort)
+  }
+
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(
+      `Invalid CDP port: ${port}. Use a port between 1 and 65535 (--port <N> or FIGMA_PORT).`
+    )
+  }
+
+  cachedCdpPort = port
+  return port
+}
+
 function isPipeMode(): boolean {
   if (pipeMode !== null) return pipeMode
   if (process.env.FIGMA_PIPE === '1') {
@@ -46,9 +93,10 @@ const pendingRequests = new Map<number, PendingRequest>()
 async function getCDPTarget(): Promise<CDPTarget> {
   if (cachedTarget) return cachedTarget
 
+  const port = getCdpPort()
   let resp: Response
   try {
-    resp = await fetch('http://localhost:9222/json')
+    resp = await fetch(`http://localhost:${port}/json`)
   } catch {
     const patched = isFigmaPatched()
     if (patched === false) {
@@ -58,8 +106,8 @@ async function getCDPTarget(): Promise<CDPTarget> {
       )
     }
     throw new Error(
-      'Cannot connect to Figma on port 9222.\n' +
-        `Start Figma with: ${figmaLaunchHint()}`
+      `Cannot connect to Figma on port ${port}.\n` +
+        `Start Figma with: ${figmaLaunchHint(port)}`
     )
   }
 
@@ -72,7 +120,7 @@ async function getCDPTarget(): Promise<CDPTarget> {
 
   if (!figmaTarget) {
     throw new Error(
-      'No Figma file open in browser.\n' + `Start Figma with: ${figmaLaunchHint()}`
+      'No Figma file open in browser.\n' + `Start Figma with: ${figmaLaunchHint(port)}`
     )
   }
 

--- a/packages/cli/src/cdp.ts
+++ b/packages/cli/src/cdp.ts
@@ -21,31 +21,45 @@ export function isPipeTransport(): boolean {
 // → FIGMA_PORT env → default 9222. Read once and cached.
 const DEFAULT_CDP_PORT = 9222
 let cachedCdpPort: number | null = null
+let cdpPortOverride: string | null = null
+
+export function setCdpPortOverride(port: string): void {
+  cdpPortOverride = port
+  cachedCdpPort = null
+}
 
 export function getCdpPort(): number {
   if (cachedCdpPort !== null) return cachedCdpPort
 
   let port = DEFAULT_CDP_PORT
+  let hasPortArg = false
 
   // Prefer an explicit --port flag on the command line. Citty does not
   // propagate root args into subcommands, so we parse argv directly — this
   // works regardless of which subcommand is running.
   const argv = process.argv
+  if (cdpPortOverride !== null) {
+    port = Number(cdpPortOverride)
+    hasPortArg = true
+  }
+
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]!
     if (a === '--port' && i + 1 < argv.length) {
       port = Number(argv[++i])
+      hasPortArg = true
       break
     }
     const eq = '--port='
     if (a.startsWith(eq)) {
       port = Number(a.slice(eq.length))
+      hasPortArg = true
       break
     }
   }
 
   // FIGMA_PORT env is the secondary fallback (matches FIGMA_PIPE/FIGMA_BIN).
-  if (!argv.includes('--port') && !argv.some((a) => a.startsWith('--port='))) {
+  if (!hasPortArg) {
     const envPort = process.env.FIGMA_PORT
     if (envPort) port = Number(envPort)
   }

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -23,6 +23,10 @@ export default defineCommand({
           description:
             'Launch Figma with --remote-debugging-pipe instead of connecting to port 9222. ' +
             'No patching required — works on Figma 126.1.2+ without admin access.'
+        },
+        port: {
+          type: 'string',
+          description: 'Chrome DevTools port Figma is listening on (default 9222, or FIGMA_PORT env)'
         }
       },
       async run({ args }) {
@@ -43,7 +47,10 @@ export default defineCommand({
 
           const daemonArgs = [indexPath, 'daemon', 'start', '-f']
           if (args.pipe) daemonArgs.push('--pipe')
-          else if (getCdpPort() !== 9222) daemonArgs.push('--port', String(getCdpPort()))
+          else {
+            const port = getCdpPort()
+            if (port !== 9222) daemonArgs.push('--port', String(port))
+          }
 
           const child = spawn(process.execPath, daemonArgs, {
             detached: true,
@@ -97,6 +104,10 @@ export default defineCommand({
         pipe: {
           type: 'boolean',
           description: 'Launch Figma with --remote-debugging-pipe'
+        },
+        port: {
+          type: 'string',
+          description: 'Chrome DevTools port Figma is listening on (default 9222, or FIGMA_PORT env)'
         }
       },
       async run({ args }) {
@@ -111,7 +122,10 @@ export default defineCommand({
 
         const daemonArgs = [indexPath, 'daemon', 'start', '-f']
         if (args.pipe) daemonArgs.push('--pipe')
-        else if (getCdpPort() !== 9222) daemonArgs.push('--port', String(getCdpPort()))
+        else {
+          const port = getCdpPort()
+          if (port !== 9222) daemonArgs.push('--port', String(port))
+        }
 
         const child = spawn(process.execPath, daemonArgs, {
           detached: true,

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url'
 
 import { startDaemon, stopDaemon, isDaemonRunning, getDaemonInfo } from '../daemon/index.ts'
 import { ok, fail } from '../format.ts'
+import { getCdpPort } from '../cdp.ts'
 
 export default defineCommand({
   meta: { name: 'daemon', description: 'Manage figma-use daemon for faster command execution' },
@@ -42,6 +43,7 @@ export default defineCommand({
 
           const daemonArgs = [indexPath, 'daemon', 'start', '-f']
           if (args.pipe) daemonArgs.push('--pipe')
+          else if (getCdpPort() !== 9222) daemonArgs.push('--port', String(getCdpPort()))
 
           const child = spawn(process.execPath, daemonArgs, {
             detached: true,
@@ -109,6 +111,7 @@ export default defineCommand({
 
         const daemonArgs = [indexPath, 'daemon', 'start', '-f']
         if (args.pipe) daemonArgs.push('--pipe')
+        else if (getCdpPort() !== 9222) daemonArgs.push('--port', String(getCdpPort()))
 
         const child = spawn(process.execPath, daemonArgs, {
           detached: true,

--- a/packages/cli/src/commands/patch.ts
+++ b/packages/cli/src/commands/patch.ts
@@ -2,6 +2,7 @@ import { defineCommand } from 'citty'
 
 import { isFigmaPatched, patchFigma } from '../patch-figma.ts'
 import { figmaLaunchHint } from '../format.ts'
+import { getCdpPort } from '../cdp.ts'
 
 export default defineCommand({
   meta: {
@@ -32,6 +33,6 @@ export default defineCommand({
     }
 
     console.log('Patched successfully.')
-    console.log(`Restart Figma with: ${figmaLaunchHint()}`)
+    console.log(`Restart Figma with: ${figmaLaunchHint(getCdpPort())}`)
   }
 })

--- a/packages/cli/src/commands/profile.ts
+++ b/packages/cli/src/commands/profile.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'child_process'
 import { defineCommand } from 'citty'
 
+import { getCdpPort } from '../cdp.ts'
 import { ok, fail, figmaLaunchHint } from '../format.ts'
 
 import type { ChromeDevToolsTarget } from '../types.ts'
@@ -13,11 +14,11 @@ export default defineCommand({
       description: 'Command to profile (e.g., "get components --limit 10")',
       required: true
     },
-    port: { type: 'string', description: 'Chrome DevTools port', default: '9222' },
+    port: { type: 'string', description: 'Chrome DevTools port' },
     top: { type: 'string', description: 'Number of top functions to show', default: '20' }
   },
   async run({ args }) {
-    const port = Number(args.port)
+    const port = args.port ? Number(args.port) : getCdpPort()
     const topN = Number(args.top)
 
     // Find Figma tab

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -2,6 +2,7 @@ import { defineCommand } from 'citty'
 
 import { getStatus, getFileKey } from '../client.ts'
 import { figmaLaunchHint } from '../format.ts'
+import { getCdpPort } from '../cdp.ts'
 
 export default defineCommand({
   meta: { description: 'Check connection status' },
@@ -33,7 +34,7 @@ export default defineCommand({
       if (result.fileKey) console.log(`  Key: ${result.fileKey}`)
     } else {
       console.log('✗ Not connected to Figma')
-      console.log(`  Start Figma with: ${figmaLaunchHint()}`)
+      console.log(`  Start Figma with: ${figmaLaunchHint(getCdpPort())}`)
       process.exit(1)
     }
   }

--- a/packages/cli/src/daemon/client.ts
+++ b/packages/cli/src/daemon/client.ts
@@ -1,6 +1,8 @@
 import { existsSync } from 'fs'
 import { createConnection, Socket } from 'net'
 
+import { getCdpPort } from '../cdp.ts'
+
 const SOCKET_PATH = '/tmp/figma-use.sock'
 
 export function isDaemonAvailable(): boolean {
@@ -30,7 +32,8 @@ export async function callDaemon<T = unknown>(command: string, args?: unknown): 
     client.on('connect', () => {
       connected = true
       clearTimeout(connectTimeout)
-      client.write(JSON.stringify({ id, command, args }) + '\n')
+      // Include the requested CDP port so the daemon can detect a mismatch.
+      client.write(JSON.stringify({ id, command, args, port: getCdpPort() }) + '\n')
     })
 
     client.on('data', (data) => {

--- a/packages/cli/src/daemon/server.ts
+++ b/packages/cli/src/daemon/server.ts
@@ -1,11 +1,12 @@
 import { existsSync, unlinkSync, writeFileSync, readFileSync } from 'fs'
 import { createServer, Server, Socket } from 'net'
 
-import { closeCDP, usePipeTransport } from '../cdp.ts'
+import { closeCDP, usePipeTransport, getCdpPort } from '../cdp.ts'
 import { sendCommandDirect } from '../client.ts'
 
 const SOCKET_PATH = '/tmp/figma-use.sock'
 const PID_FILE = '/tmp/figma-use.pid'
+const PORT_FILE = '/tmp/figma-use.port'
 
 let server: Server | null = null
 
@@ -13,6 +14,7 @@ interface Request {
   id: string
   command: string
   args?: unknown
+  port?: number
 }
 
 interface Response {
@@ -40,6 +42,20 @@ function handleConnection(socket: Socket): void {
         const response: Response = { id: req.id, ok: true }
 
         try {
+          // Guard against port mismatch: a daemon serving port A must not
+          // silently serve a client that asked for port B (different Figma).
+          const servingPort = getDaemonPort()
+          if (
+            req.port !== undefined &&
+            servingPort !== null &&
+            req.port !== servingPort
+          ) {
+            throw new Error(
+              `Daemon is serving port ${servingPort}, but this command requested port ${req.port}. ` +
+                `Restart the daemon with: figma-use daemon restart --port ${req.port}`
+            )
+          }
+
           // Use direct command (no daemon loop, cached RPC)
           response.result = await sendCommandDirect(req.command, req.args)
         } catch (e) {
@@ -82,10 +98,13 @@ export async function startDaemon(options?: { pipe?: boolean }): Promise<void> {
   server = createServer(handleConnection)
 
   server.listen(SOCKET_PATH, () => {
-    // Write PID file
+    // Write PID + serving port files
     writeFileSync(PID_FILE, String(process.pid))
+    const port = isPipeTransport() ? null : getCdpPort()
+    if (port !== null) writeFileSync(PORT_FILE, String(port))
     console.log(`Daemon started (PID ${process.pid})`)
     console.log(`Socket: ${SOCKET_PATH}`)
+    if (port !== null && port !== 9222) console.log(`CDP port: ${port}`)
   })
 
   server.on('error', (e) => {
@@ -99,6 +118,7 @@ export async function startDaemon(options?: { pipe?: boolean }): Promise<void> {
     await closeCDP()
     if (existsSync(SOCKET_PATH)) unlinkSync(SOCKET_PATH)
     if (existsSync(PID_FILE)) unlinkSync(PID_FILE)
+    if (existsSync(PORT_FILE)) unlinkSync(PORT_FILE)
     process.exit(0)
   }
 
@@ -118,11 +138,13 @@ export function stopDaemon(): boolean {
     // Clean up files
     if (existsSync(SOCKET_PATH)) unlinkSync(SOCKET_PATH)
     if (existsSync(PID_FILE)) unlinkSync(PID_FILE)
+    if (existsSync(PORT_FILE)) unlinkSync(PORT_FILE)
     return true
   } catch {
     // Process not running, clean up stale files
     if (existsSync(SOCKET_PATH)) unlinkSync(SOCKET_PATH)
     if (existsSync(PID_FILE)) unlinkSync(PID_FILE)
+    if (existsSync(PORT_FILE)) unlinkSync(PORT_FILE)
     return false
   }
 }
@@ -138,6 +160,14 @@ export function isDaemonRunning(): boolean {
   } catch {
     return false
   }
+}
+
+// The CDP port the running daemon is serving (null = pipe mode or unknown).
+export function getDaemonPort(): number | null {
+  if (!isDaemonRunning()) return null
+  if (!existsSync(PORT_FILE)) return null
+  const port = parseInt(readFileSync(PORT_FILE, 'utf-8'))
+  return Number.isNaN(port) ? null : port
 }
 
 export function getDaemonInfo(): { pid: number; socket: string } | null {

--- a/packages/cli/src/daemon/server.ts
+++ b/packages/cli/src/daemon/server.ts
@@ -1,7 +1,7 @@
 import { existsSync, unlinkSync, writeFileSync, readFileSync } from 'fs'
 import { createServer, Server, Socket } from 'net'
 
-import { closeCDP, usePipeTransport, getCdpPort } from '../cdp.ts'
+import { closeCDP, usePipeTransport, isPipeTransport, getCdpPort } from '../cdp.ts'
 import { sendCommandDirect } from '../client.ts'
 
 const SOCKET_PATH = '/tmp/figma-use.sock'
@@ -64,7 +64,7 @@ function handleConnection(socket: Socket): void {
         }
 
         socket.write(JSON.stringify(response) + '\n')
-      } catch (e) {
+      } catch {
         socket.write(JSON.stringify({ id: 'error', ok: false, error: 'Invalid JSON' }) + '\n')
       }
     }
@@ -84,6 +84,9 @@ export async function startDaemon(options?: { pipe?: boolean }): Promise<void> {
   // Clean up existing socket
   if (existsSync(SOCKET_PATH)) {
     unlinkSync(SOCKET_PATH)
+  }
+  if (existsSync(PORT_FILE)) {
+    unlinkSync(PORT_FILE)
   }
 
   // Pre-warm: build RPC and connect to Figma once

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,12 @@ const main = defineCommand({
       'Control Figma from the command line. Supports JSX rendering with components and variants — see `figma-use render --examples`',
     version
   },
+  args: {
+    port: {
+      type: 'string',
+      description: 'Chrome DevTools port Figma is listening on (default 9222, or FIGMA_PORT env)'
+    }
+  },
   subCommands: commands
 })
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,8 +1,25 @@
 import { defineCommand, runMain } from 'citty'
 
 import { version } from '../../../package.json'
-import { closeCDP } from './cdp.ts'
+import { closeCDP, setCdpPortOverride } from './cdp.ts'
 import * as commands from './commands/index.ts'
+
+function normalizeGlobalPortArg(): void {
+  const args = process.argv.slice(2)
+  const portIndex = args.findIndex((arg) => arg === '--port' || arg.startsWith('--port='))
+  if (portIndex === -1) return
+
+  const firstCommandIndex = args.findIndex((arg) => !arg.startsWith('-'))
+  if (firstCommandIndex !== -1 && portIndex > firstCommandIndex) return
+
+  const raw = args[portIndex]!
+  const value = raw === '--port' ? args[portIndex + 1] : raw.slice('--port='.length)
+  if (value === undefined) return
+
+  setCdpPortOverride(value)
+  const deleteCount = raw === '--port' ? 2 : 1
+  process.argv.splice(portIndex + 2, deleteCount)
+}
 
 const main = defineCommand({
   meta: {
@@ -22,4 +39,5 @@ const main = defineCommand({
 
 process.on('beforeExit', () => closeCDP())
 
+normalizeGlobalPortArg()
 runMain(main)

--- a/packages/cli/tests/commands/port.test.ts
+++ b/packages/cli/tests/commands/port.test.ts
@@ -9,14 +9,29 @@ const CLI_BIN = join(import.meta.dir, '../../../../dist/cli/index.js')
 // getCdpPort caches its result, so each scenario runs in a fresh subprocess
 // with a controlled argv. This also mirrors how the flag is actually parsed
 // in real CLI invocations.
-function runWithArgs(args: string[], env?: Record<string, string>): Promise<string> {
+async function runWithArgs(args: string[], env?: Record<string, string>): Promise<string> {
   const proc = Bun.spawn([process.execPath, CLI_BIN, 'status', ...args], {
     cwd: import.meta.dir,
     stdout: 'pipe',
     stderr: 'pipe',
     env: { ...process.env, ...env }
   })
-  return new Response(proc.stdout).text()
+  return await new Response(proc.stdout).text()
+}
+
+async function runCli(args: string[], env?: Record<string, string>): Promise<string> {
+  const proc = Bun.spawn([process.execPath, CLI_BIN, ...args], {
+    cwd: import.meta.dir,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: { ...process.env, ...env }
+  })
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text()
+  ])
+  await proc.exited
+  return stdout + stderr
 }
 
 describe('custom CDP port', () => {
@@ -28,6 +43,16 @@ describe('custom CDP port', () => {
   test('--port=<N> form works', async () => {
     const out = await runWithArgs(['--port=8444'])
     expect(out).toContain('remote-debugging-port=8444')
+  })
+
+  test('root-level --port <N> before command works', async () => {
+    const out = await runCli(['--port', '9556', 'status'])
+    expect(out).toContain('remote-debugging-port=9556')
+  })
+
+  test('root-level --port=<N> before command works', async () => {
+    const out = await runCli(['--port=9557', 'status'])
+    expect(out).toContain('remote-debugging-port=9557')
   })
 
   test('FIGMA_PORT env is used when no flag is given', async () => {

--- a/packages/cli/tests/commands/port.test.ts
+++ b/packages/cli/tests/commands/port.test.ts
@@ -34,6 +34,21 @@ async function runCli(args: string[], env?: Record<string, string>): Promise<str
   return stdout + stderr
 }
 
+async function resolvePort(env?: Record<string, string>): Promise<string> {
+  const repoRoot = join(import.meta.dir, '../../../../')
+  const proc = Bun.spawn([
+    process.execPath,
+    '-e',
+    "import { getCdpPort } from './packages/cli/src/cdp.ts'; console.log(getCdpPort())"
+  ], {
+    cwd: repoRoot,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: { ...process.env, ...env }
+  })
+  return (await new Response(proc.stdout).text()).trim()
+}
+
 describe('custom CDP port', () => {
   test('--port <N> is reflected in the connection hint', async () => {
     const out = await runWithArgs(['--port', '9555'])
@@ -67,7 +82,6 @@ describe('custom CDP port', () => {
   })
 
   test('defaults to 9222 when nothing is specified', async () => {
-    const out = await runWithArgs([], { FIGMA_PORT: '' })
-    expect(out).toContain('remote-debugging-port=9222')
+    await expect(resolvePort({ FIGMA_PORT: '' })).resolves.toBe('9222')
   })
 })

--- a/packages/cli/tests/commands/port.test.ts
+++ b/packages/cli/tests/commands/port.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect } from 'bun:test'
+import { join } from 'path'
+
+// dist/ lives at the repo root. Resolve from the test file's own location
+// (packages/cli/tests/commands/) so the path is stable regardless of cwd:
+// commands → tests → cli → packages → root = 4 levels up.
+const CLI_BIN = join(import.meta.dir, '../../../../dist/cli/index.js')
+
+// getCdpPort caches its result, so each scenario runs in a fresh subprocess
+// with a controlled argv. This also mirrors how the flag is actually parsed
+// in real CLI invocations.
+function runWithArgs(args: string[], env?: Record<string, string>): Promise<string> {
+  const proc = Bun.spawn([process.execPath, CLI_BIN, 'status', ...args], {
+    cwd: import.meta.dir,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: { ...process.env, ...env }
+  })
+  return new Response(proc.stdout).text()
+}
+
+describe('custom CDP port', () => {
+  test('--port <N> is reflected in the connection hint', async () => {
+    const out = await runWithArgs(['--port', '9555'])
+    expect(out).toContain('remote-debugging-port=9555')
+  })
+
+  test('--port=<N> form works', async () => {
+    const out = await runWithArgs(['--port=8444'])
+    expect(out).toContain('remote-debugging-port=8444')
+  })
+
+  test('FIGMA_PORT env is used when no flag is given', async () => {
+    const out = await runWithArgs([], { FIGMA_PORT: '7331' })
+    expect(out).toContain('remote-debugging-port=7331')
+  })
+
+  test('--port flag takes precedence over FIGMA_PORT env', async () => {
+    const out = await runWithArgs(['--port', '6000'], { FIGMA_PORT: '7000' })
+    expect(out).toContain('remote-debugging-port=6000')
+    expect(out).not.toContain('remote-debugging-port=7000')
+  })
+
+  test('defaults to 9222 when nothing is specified', async () => {
+    const out = await runWithArgs([], { FIGMA_PORT: '' })
+    expect(out).toContain('remote-debugging-port=9222')
+  })
+})


### PR DESCRIPTION
## What

All commands previously hardcoded the Figma remote-debugging port to `9222` (in `packages/cli/src/cdp.ts`, the single chokepoint every command flows through). Only the isolated `profile` command supported a custom port. This makes the port configurable everywhere.

## How

- **`--port <N>`** flag — works both as a root-level flag (`figma-use --port 9333 get components`) and after the subcommand (`figma-use get components --port 9333`).
- **`FIGMA_PORT`** env var — secondary fallback, matching the existing `FIGMA_PIPE`/`FIGMA_BIN` convention.
- Precedence: `--port` flag → `FIGMA_PORT` → `9222`.

### Implementation
- `cdp.ts`: new `getCdpPort()` resolves the port once (validated 1–65535) and caches it; `getCDPTarget()` and error messages use it. `setCdpPortOverride()` lets the root-command wrapper hand off a pre-subcommand `--port`.
- `index.ts`: declares `--port` on the root command (so it appears in `--help`) and `normalizeGlobalPortArg()` strips a pre-subcommand `--port` from argv into the override — because citty does not propagate root args into subcommands, this avoids an unknown-flag error.
- `daemon`: `start`/`restart` declare `--port` and forward it to the spawned daemon; the client sends its requested port; the server records its serving port (`/tmp/figma-use.port`) and rejects mismatches with a restart hint rather than silently hitting the wrong Figma.
- `status`, `patch`, `profile`: launch hints / defaults now reflect the actual port instead of a hardcoded 9222.

## Verification
- `bun run build` ✓
- `bun run lint` — 0 errors (removed an unused `catch` param); remaining warnings are all pre-existing in unrelated files.
- `bun test tests/commands/port.test.ts` — 7/7 pass: `--port N`, `--port=N`, root-level `--port`, `FIGMA_PORT`, flag-over-env precedence, and default.

## Notes
- Pipe transport (`--remote-debugging-pipe`) is unaffected — it spawns Figma directly with no port.
- Daemon mismatch path verified in isolation: a daemon serving 9220 rejecting a client requesting 9333 with a clear restart hint.
- No version bump or publish (per AGENTS.md, that's the maintainer's call).