### PR TITLE
fix: support Figma 126.6+ rspack migration

### DIFF
--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -92,7 +92,8 @@ const FIGMA_API_BOOTSTRAP = `
   if (window.__figmaPluginApi && typeof window.__figmaPluginApi.getNodeByIdAsync === 'function' && typeof window.__figmaPluginApi.loadFontAsync === 'function') return 'already available';
 
   if (!window.__webpackRequire__) {
-    window.webpackChunk_figma_web_bundler.push([
+    var _chunk = window.webpackChunk_figma_web_bundler || window.rspackChunk_figma_web_bundler;
+    _chunk.push([
       ['__figma_use_' + Date.now()], {},
       r => window.__webpackRequire__ = r
     ]);
@@ -101,9 +102,10 @@ const FIGMA_API_BOOTSTRAP = `
   const r = window.__webpackRequire__;
   let defineVm;
   for (const id in r.m) {
-    if (r.m[id].toString().includes('apiMode:e,pluginID')) {
+    const src = r.m[id].toString();
+    if (src.includes('apiMode') && src.includes('pluginID') && src.includes('sceneGraph')) {
       const hit = Object.values(r(id)).find(
-        v => typeof v === 'function' && v.toString().includes('apiMode')
+        v => typeof v === 'function' && v.length === 1 && v.toString().includes('apiMode') && v.toString().includes('sceneGraph')
       );
       if (hit) { defineVm = hit; break; }
     }


### PR DESCRIPTION
## Summary

Figma 126.6+ (Electron 42 / Chrome 148) replaced webpack with rspack, breaking the plugin API bootstrap:

- **`rspackChunk` fallback** — `window.webpackChunk_figma_web_bundler` no longer exists; try it first for backward compat, then fall back to `window.rspackChunk_figma_web_bundler`
- **Relaxed module filter** — the old hardcoded `apiMode:e,pluginID` signature breaks under rspack's different minified param names; switched to generic `includes()` checks for `apiMode`, `pluginID`, and `sceneGraph`
- **`v.length === 1` discriminator** — the module now exports both a zero-argument config factory and the actual `defineVm` (1 argument); matching on arity prevents picking the wrong function, which caused `TypeError: figma.loadFontAsync is not a function`
- **`sceneGraph` requirement** — further narrows the match since only `defineVm` references `sceneGraph` in its destructured params

## Test plan

- [x] Tested on Figma 126.6.9, macOS Darwin 24.6.0, figma-use 0.13.3
- [x] `eval`, `page list`, `render`, `variable list` all work
- [x] Backward-compatible with pre-126.6 webpack-based Figma (webpackChunk checked first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)